### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build App
+permissions:
+  contents: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Headpat-Community/headpat-app/security/code-scanning/11](https://github.com/Headpat-Community/headpat-app/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: read` is needed for the workflow to read repository contents.
- `contents: write` is required for the "🔢 Increment build numbers" step, which performs a `git push` operation to update the `app.json` file.
- No other permissions are necessary for this workflow.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
